### PR TITLE
Terraform fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use this module you need to create a Terraform configuration that utilizes th
 
 ```hcl
 module "epsagon_aws_integration" {
-  source                    = "github.com/epsagon/epsagon-terraform?ref=v3.0.1"
+  source                    = "github.com/epsagon/epsagon-terraform?ref=3.0.1"
   epsagon_account_id        = "<EPSAGON_AWS_ACCOUNT_ID>"
   epsagon_external_id       = "<EPSAGON_AWS_EXTERNAL_ID>"
   epsagon_sns_name          = "<EPSAGON_SNS_NAME>"

--- a/main.tf
+++ b/main.tf
@@ -23,9 +23,9 @@ resource "aws_cloudformation_stack" "epsagon" {
   capabilities = ["CAPABILITY_NAMED_IAM"]
 
   parameters {
-    AWSAccount         = "${var.epsagon_account_id}",
-    ExternalId         = "${var.epsagon_external_id}",
-    EpsagonSns         = "${var.epsagon_sns_name}",
-    ExternalBucketName = "${aws_s3_bucket.epsagon-trail.id}",
+    AWSAccount         = "${var.epsagon_account_id}"
+    ExternalId         = "${var.epsagon_external_id}"
+    EpsagonSns         = "${var.epsagon_sns_name}"
+    ExternalBucketName = "${aws_s3_bucket.epsagon-trail.id}"
   }
 }


### PR DESCRIPTION
Just a very quick fix, that allows `terraform fmt` to be quiet (we have `fmt` in our CI and when importing the module the CI complains):

Before:

```shell
$ terraform fmt -diff
main.tf
diff a/main.tf b/main.tf
--- /tmp/147002336      2019-04-19 11:51:31.749088791 +0200
+++ /tmp/329914815      2019-04-19 11:51:31.749088791 +0200
@@ -23,9 +23,9 @@
   capabilities = ["CAPABILITY_NAMED_IAM"]

   parameters {
-    AWSAccount         = "${var.epsagon_account_id}",
-    ExternalId         = "${var.epsagon_external_id}",
-    EpsagonSns         = "${var.epsagon_sns_name}",
-    ExternalBucketName = "${aws_s3_bucket.epsagon-trail.id}",
+    AWSAccount         = "${var.epsagon_account_id}"
+    ExternalId         = "${var.epsagon_external_id}"
+    EpsagonSns         = "${var.epsagon_sns_name}"
+    ExternalBucketName = "${aws_s3_bucket.epsagon-trail.id}"
   }
 }
```