### PR TITLE
Include account_id in bucket name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "epsagon-trail" {
-  bucket = "epsagon-trail-bucket"
+  bucket_prefix = "epsagon-trail-bucket"
 
   force_destroy = true
 


### PR DESCRIPTION
Bucket names must be unique: https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html

This change defines a `bucket_prefix` instead of the `bucket` name to
have a unique name and avoid this terraform error:

    aws_s3_bucket.epsagon-trail: Error creating S3 bucket: BucketAlreadyExists:
    The requested bucket name is not available. The bucket namespace is shared
    by all users of the system.

Terraform documentation about `bucket` and `bucket_prefix`
https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#bucket_prefix :

> bucket - (Optional, Forces new resource) The name of the bucket. If omitted,
> Terraform will assign a random, unique name.
> bucket_prefix - (Optional, Forces new resource) Creates a unique bucket name
> beginning with the specified prefix. Conflicts with bucket.

---

Sorry I didn't tried it _at the same time_ with multiple accounts :-/
Now as only a prefix is set, a unique name is generated and avoid conflicts. By example:
![image](https://user-images.githubusercontent.com/1542321/56966585-aec93d80-6b5f-11e9-935b-40cb05534119.png)
