### PR TITLE
Update to support terraform 0.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use this module you need to create a Terraform configuration that utilizes th
 
 ```hcl
 module "epsagon_aws_integration" {
-  source                    = "github.com/epsagon/epsagon-terraform?ref=3.0.3"
+  source                    = "github.com/epsagon/epsagon-terraform?ref=3.0.4"
   epsagon_account_id        = "066549572091"
   epsagon_external_id       = "<EPSAGON_AWS_EXTERNAL_ID>"
   epsagon_sns_name          = "cloudformation-status-production"

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_s3_bucket" "epsagon-trail" {
     }
   }
 
-  tags {
+  tags = {
     Name = "Epsagon CloudTrail bucket"
   }
 }
@@ -22,7 +22,7 @@ resource "aws_cloudformation_stack" "epsagon" {
   template_url = "https://s3.amazonaws.com/epsagon-cloudformation/terraform_template.json"
   capabilities = ["CAPABILITY_NAMED_IAM"]
 
-  parameters {
+  parameters = {
     AWSAccount         = "${var.epsagon_account_id}"
     ExternalId         = "${var.epsagon_external_id}"
     EpsagonSns         = "${var.epsagon_sns_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,20 +1,20 @@
 variable "aws_iam_role_name" {
-  type        = "string"
+  type        = string
   description = "Epsagon IAM role name"
   default     = "EpsagonRole"
 }
 
 variable "epsagon_account_id" {
-  type        = "string"
+  type        = string
   description = "Epsagon AWS account ID"
 }
 
 variable "epsagon_external_id" {
-  type        = "string"
+  type        = string
   description = "Epsagon AWS external ID"
 }
 
 variable "epsagon_sns_name" {
-  type        = "string"
+  type        = string
   description = "The Epsagon SNS Name for CF callback."
 }


### PR DESCRIPTION
Terraform 0.12 and onwards (i.e. latest version) doesn't work. This updates to the latest version.

I have assumed we're going to bump 3.0.3 -> 3.0.4 so I changed the readme to 3.0.4 let me know if you'd rather do a 3.1.0 or a 4.0.0.